### PR TITLE
fix: block bootstrap until remote circuit config loads

### DIFF
--- a/libs/ngx-circuit/src/index.ts
+++ b/libs/ngx-circuit/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/circuit-directive/circuit.directive';
 export * from './lib/circuit-guard/circuit.guard';
 export * from './lib/circuit-context/circuit.context';
 export * from './lib/circuit-analytics/circuit.analytics';
+export * from './lib/circuit-initializer/circuit.initializer';

--- a/libs/ngx-circuit/src/lib/circuit-initializer/circuit.initializer.ts
+++ b/libs/ngx-circuit/src/lib/circuit-initializer/circuit.initializer.ts
@@ -1,0 +1,26 @@
+import {
+  EnvironmentProviders,
+  inject,
+  provideAppInitializer,
+} from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, firstValueFrom } from 'rxjs';
+import { CircuitService } from '../circuit-service/circuit.service';
+
+/**
+ * Creates an Angular app initializer that blocks bootstrap until the remote
+ * circuit config has finished loading (success or error).
+ *
+ * This ensures that components reading feature flags at construction time
+ * (e.g. via field initializers or in the constructor) receive the correct
+ * flag values rather than empty defaults.
+ */
+export function provideCircuitInitializer(): EnvironmentProviders {
+  return provideAppInitializer(() => {
+    const circuit = inject(CircuitService);
+    return firstValueFrom(
+      toObservable(circuit.loading).pipe(filter((loading) => !loading)),
+      { defaultValue: false },
+    );
+  });
+}

--- a/libs/ngx-circuit/src/lib/circuit.config.ts
+++ b/libs/ngx-circuit/src/lib/circuit.config.ts
@@ -4,6 +4,7 @@ import {
   makeEnvironmentProviders,
   Provider,
 } from '@angular/core';
+import { provideCircuitInitializer } from './circuit-initializer/circuit.initializer';
 
 export enum CircuitType {
   Boolean = 'BOOLEAN',
@@ -101,5 +102,6 @@ export function provideRemoteCircuitConfig(
       provide: CIRCUIT_OPTIONS,
       useValue: options,
     },
+    provideCircuitInitializer(),
   ]);
 }


### PR DESCRIPTION
## Summary

`provideRemoteCircuitConfig()` now blocks Angular's bootstrap until the remote feature flag HTTP request completes, ensuring components receive correct flag values at construction time.

Closes #24

## Problem

Components reading flags at field initialization or in constructors received `false` for flags that were actually `true` in the remote config, because the HTTP request hadn't completed yet:

```typescript
export class MyComponent {
  public featureOn = this._circuit.isEnabled('myFlag'); // always false before HTTP completes
}
```

## Solution

Added a `provideAppInitializer` inside `provideRemoteCircuitConfig` that watches `CircuitService.loading` and resolves only when loading becomes `false` (success or error). This blocks Angular's bootstrap until flags are available.

### New file: `circuit-initializer/circuit.initializer.ts`

Exports `provideCircuitInitializer()` — uses `toObservable(circuit.loading)` + `firstValueFrom` to create an app initializer that blocks until config loading completes.

### Modified: `circuit.config.ts`

`provideRemoteCircuitConfig` now includes `provideCircuitInitializer()` in its providers.

### Modified: `index.ts`

Re-exports `provideCircuitInitializer` so consumers can use it standalone if needed.

## Testing

All 23 existing tests pass with zero errors.